### PR TITLE
Initialize state with publishable models

### DIFF
--- a/app/models/concerns/publishable.rb
+++ b/app/models/concerns/publishable.rb
@@ -3,10 +3,19 @@ module Publishable
 
   included do
     belongs_to :state, dependent: :destroy
+
+    after_initialize :create_state
+
     scope :published, -> { joins(:state).where('states.state = ?', State.states[:published]) }
   end
 
   def published?
     state.published?
   end
+
+  private
+
+    def create_state
+      self.state = State.new unless state.present?
+    end
 end

--- a/spec/models/concerns/publishable_shared_examples.rb
+++ b/spec/models/concerns/publishable_shared_examples.rb
@@ -32,4 +32,10 @@ shared_examples_for 'publishable' do
     create(model.to_s.underscore.to_sym)
     expect(model.published).to match_array([published1, published2])
   end
+
+  it 'creates state when initialized ' do
+    instance = model.new
+    expect(instance.state).not_to be(nil)
+    expect(instance.state).to be_a(State)
+  end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review

## Review progress:

- [ ] Tech review completed

## What's changed?

* Create linked model state when model is initialized. This means you won't need to manually create a models state before you can save it when creating a new object. The default state is unpublished.
