### PR TITLE
Adds years to key stage and orders them by level

### DIFF
--- a/app/dashboards/key_stage_dashboard.rb
+++ b/app/dashboards/key_stage_dashboard.rb
@@ -10,7 +10,7 @@ class KeyStageDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     year_groups: Field::HasMany,
     teacher_guide: Field::ActiveStorage.with_options(
-      destroy_url: proc do |namespace, resource, attachment|
+      destroy_url: proc do |_namespace, resource, attachment|
         [:admin_key_stage_teacher_guide, { attachment_id: attachment.id,
                                            key_stage_id: resource.id }]
       end
@@ -19,6 +19,7 @@ class KeyStageDashboard < Administrate::BaseDashboard
     level: Field::String,
     description: Field::Text,
     ages: Field::String,
+    years: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     'published?': Field::Boolean
@@ -44,6 +45,7 @@ class KeyStageDashboard < Administrate::BaseDashboard
     description
     teacher_guide
     ages
+    years
     published?
     created_at
     updated_at
@@ -55,6 +57,7 @@ class KeyStageDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
     ages
+    years
     level
     description
     teacher_guide

--- a/app/graphql/types/key_stage_type.rb
+++ b/app/graphql/types/key_stage_type.rb
@@ -5,6 +5,7 @@ module Types
     field :short_title, String, null: false
     field :level, String, null: false
     field :ages, String, null: false
+    field :years, String, null: false
     field :teacher_guide, String, null: true
     field :description, String, null: false
     field :year_groups, [Types::YearGroupType], null: true, method: :published_year_groups

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -37,7 +37,7 @@ module Types
 
     # key stages
     def key_stages
-      KeyStage.published
+      KeyStage.published.ordered
     end
 
     def key_stage(id:)

--- a/app/models/key_stage.rb
+++ b/app/models/key_stage.rb
@@ -6,10 +6,12 @@ class KeyStage < ApplicationRecord
   has_one_attached :teacher_guide
 
   validates :description, :level, presence: true
-  validates :ages, :level, uniqueness: true
-  validates :ages, format: { with: /\A^[0-9]+(-[0-9]+)$\z/,
-                             multiline: true,
-                             message: 'Please use the following format: 3-5' }
+  validates :ages, :level, :years, uniqueness: true
+  validates :ages, :years, format: { with: /\A^[0-9]+(-[0-9]+)$\z/,
+                                     multiline: true,
+                                     message: 'Please use the following format: 3-5' }
+
+  scope :ordered, -> { order(:level) }
 
   def short_title
     "KS#{level}"

--- a/db/migrate/20200707111726_add_years_to_key_stages.rb
+++ b/db/migrate/20200707111726_add_years_to_key_stages.rb
@@ -1,0 +1,5 @@
+class AddYearsToKeyStages < ActiveRecord::Migration[6.0]
+  def change
+    add_column :key_stages, :years, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_30_075010) do
+ActiveRecord::Schema.define(version: 2020_07_07_111726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -60,6 +60,7 @@ ActiveRecord::Schema.define(version: 2020_06_30_075010) do
     t.uuid "state_id"
     t.string "level"
     t.string "ages"
+    t.string "years"
   end
 
   create_table "lessons", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/key_stage.rb
+++ b/spec/factories/key_stage.rb
@@ -2,7 +2,8 @@ FactoryBot.define do
   factory :key_stage do
     sequence(:level, &:to_s)
     sequence(:description) { |n| "Key Stage 3, or KS3, is the part taught to children between the ages of 11 and 14. KS3 begins when pupils start secondary education - #{n}" }
-    sequence(:ages) { |n| "#{n}-#{n+2}" }
+    sequence(:ages) { |n| "#{n}-#{n + 2}" }
+    sequence(:years) { |n| "#{n}-#{n + 2}" }
     state
 
     factory :published_key_stage do

--- a/spec/models/key_stage_spec.rb
+++ b/spec/models/key_stage_spec.rb
@@ -19,13 +19,22 @@ RSpec.describe KeyStage, type: :model do
     it { is_expected.to validate_presence_of(:level) }
     it { is_expected.to validate_uniqueness_of(:level).case_insensitive }
 
-    it 'does restricts the format for the ages field' do
+    it 'restricts the format for the ages field' do
       expect(key_stage.valid?).to eq true
 
       key_stage.ages = '1-B'
       key_stage.valid?
 
       expect(key_stage.errors[:ages]).to include('Please use the following format: 3-5')
+    end
+
+    it 'restricts the format for the years field' do
+      expect(key_stage.valid?).to eq true
+
+      key_stage.years = '1-B'
+      key_stage.valid?
+
+      expect(key_stage.errors[:years]).to include('Please use the following format: 3-5')
     end
   end
 


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*
* Related to tc#1254


## What's changed?

* Add `years` field to key_stages to allow easy display of information like `Year 9-11` on front end.
* Make `years` editable on administrate dashboard
* Order key stages by `level` when returning from graphql api

## Steps to perform after deploying to production

* Add years values to existing key_stages
