### PR TITLE
lock down routes for KeyStage and YearGroup

### DIFF
--- a/app/dashboards/key_stage_dashboard.rb
+++ b/app/dashboards/key_stage_dashboard.rb
@@ -58,12 +58,7 @@ class KeyStageDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    ages
-    years
-    level
     description
-    teacher_guide
-    year_groups
   ].freeze
 
   # COLLECTION_FILTERS

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   root to: redirect('/admin')
 
   namespace :admin do
-    resources :key_stages, only: %i[show index] do
+    resources :key_stages, only: %i[show edit index] do
       post '/publish', to: 'key_stages#publish'
       post '/unpublish', to: 'key_stages#unpublish'
       delete :teacher_guide, action: :destroy_teacher_guide


### PR DESCRIPTION
## Status

* Current Status: Ready
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/1295

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Ensures a yearGroup and a keystage cannot be deleted. KeyStage only description can be edited.


