### PR TITLE
Override blobs controller to allow extending behaviour

### DIFF
--- a/app/controllers/active_storage/blobs_controller.rb
+++ b/app/controllers/active_storage/blobs_controller.rb
@@ -1,0 +1,13 @@
+class ActiveStorage::BlobsController < ActiveStorage::BaseController
+  include ActiveStorage::SetBlob
+  after_action :track_download
+
+  def show
+    expires_in ActiveStorage.service_urls_expire_in
+    redirect_to @blob.service_url(disposition: params[:disposition])
+  end
+
+  private
+
+    def track_download; end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*


## What's changed?

* Copy the ActiveStorage::BlobsController into the rails app. This will allow us to extend with an after_action to track downloads, and also ensure files are downloaded via the cdn.
