### PR TITLE
Change active record has_many behaviour on update

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Curriculum
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.active_storage.replace_on_assign_to_many = false
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION


## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*
* Closes tc#1278

## Review progress:

- [ ] Tech review completed

## What's changed?

Rails 6 defaults to removing existing files when you update a has_many attachment.
This causes existing files to be deleted when you add another to an active storage has_many_attached record.

* Change the default behaviour in config
