### PR TITLE
Add user stem achiever number to ratings requests

### DIFF
--- a/app/graphql/mutations/add_negative_lesson_rating.rb
+++ b/app/graphql/mutations/add_negative_lesson_rating.rb
@@ -1,14 +1,15 @@
 module Mutations
   class AddNegativeLessonRating < BaseMutation
     argument :id, ID, required: true
+    argument :user_stem_achiever_contact_no, ID, required: false
 
     field :lesson, Types::LessonType, null: false
 
     type Types::LessonType
 
-    def resolve(id:)
+    def resolve(id:, user_stem_achiever_contact_no: nil)
       lesson = Lesson.find(id)
-      lesson.add_negative_rating
+      lesson.add_negative_rating(user_stem_achiever_contact_no)
       lesson
     end
   end

--- a/app/graphql/mutations/add_negative_unit_rating.rb
+++ b/app/graphql/mutations/add_negative_unit_rating.rb
@@ -1,14 +1,15 @@
 module Mutations
   class AddNegativeUnitRating < BaseMutation
     argument :id, ID, required: true
+    argument :user_stem_achiever_contact_no, ID, required: false
 
     field :unit, Types::UnitType, null: false
 
     type Types::UnitType
 
-    def resolve(id:)
+    def resolve(id:, user_stem_achiever_contact_no: nil)
       unit = Unit.find(id)
-      unit.add_negative_rating
+      unit.add_negative_rating(user_stem_achiever_contact_no)
       unit
     end
   end

--- a/app/graphql/mutations/add_positive_lesson_rating.rb
+++ b/app/graphql/mutations/add_positive_lesson_rating.rb
@@ -1,14 +1,15 @@
 module Mutations
   class AddPositiveLessonRating < BaseMutation
     argument :id, ID, required: true
+    argument :user_stem_achiever_contact_no, ID, required: false
 
     field :lesson, Types::LessonType, null: false
 
     type Types::LessonType
 
-    def resolve(id:)
+    def resolve(id:, user_stem_achiever_contact_no: nil)
       lesson = Lesson.find(id)
-      lesson.add_positive_rating
+      lesson.add_positive_rating(user_stem_achiever_contact_no)
       lesson
     end
   end

--- a/app/graphql/mutations/add_positive_unit_rating.rb
+++ b/app/graphql/mutations/add_positive_unit_rating.rb
@@ -1,14 +1,15 @@
 module Mutations
   class AddPositiveUnitRating < BaseMutation
     argument :id, ID, required: true
+    argument :user_stem_achiever_contact_no, ID, required: false
 
     field :unit, Types::UnitType, null: false
 
     type Types::UnitType
 
-    def resolve(id:)
+    def resolve(id:, user_stem_achiever_contact_no: nil)
       unit = Unit.find(id)
-      unit.add_positive_rating
+      unit.add_positive_rating(user_stem_achiever_contact_no)
       unit
     end
   end

--- a/app/models/aggregate_rating.rb
+++ b/app/models/aggregate_rating.rb
@@ -2,16 +2,22 @@ class AggregateRating < ApplicationRecord
   belongs_to :rateable, polymorphic: true
   has_many :ratings, dependent: :destroy
 
-  def add_positive_rating
-    ratings.create(positive: true)
+  def add_positive_rating(user_stem_achiever_contact_no = nil)
+    ratings.create(
+      positive: true,
+      user_stem_achiever_contact_no: user_stem_achiever_contact_no
+    )
 
     with_lock do
       increment!(:total_positive)
     end
   end
 
-  def add_negative_rating
-    ratings.create(positive: false)
+  def add_negative_rating(user_stem_achiever_contact_no = nil)
+    ratings.create(
+      positive: false,
+      user_stem_achiever_contact_no: user_stem_achiever_contact_no
+    )
 
     with_lock do
       increment!(:total_negative)

--- a/db/migrate/20200826080339_add_user_stem_achiever_contact_no_to_ratings.rb
+++ b/db/migrate/20200826080339_add_user_stem_achiever_contact_no_to_ratings.rb
@@ -1,0 +1,6 @@
+class AddUserStemAchieverContactNoToRatings < ActiveRecord::Migration[6.0]
+  def change
+    add_column :ratings, :user_stem_achiever_contact_no, :uuid
+    add_index :ratings, :user_stem_achiever_contact_no
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_14_085446) do
+ActiveRecord::Schema.define(version: 2020_08_26_080339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -94,7 +94,9 @@ ActiveRecord::Schema.define(version: 2020_08_14_085446) do
     t.boolean "positive", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "user_stem_achiever_contact_no"
     t.index ["aggregate_rating_id"], name: "index_ratings_on_aggregate_rating_id"
+    t.index ["user_stem_achiever_contact_no"], name: "index_ratings_on_user_stem_achiever_contact_no"
   end
 
   create_table "states", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/models/aggregate_rating_spec.rb
+++ b/spec/models/aggregate_rating_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe AggregateRating, type: :model do
   subject(:new_aggregate) { create(:aggregate_rating) }
 
+  let(:user_stem_achiever_contact_no) { SecureRandom.uuid }
+
   it { is_expected.to have_many(:ratings) }
 
   describe '#add_positive_rating' do
@@ -15,6 +17,24 @@ RSpec.describe AggregateRating, type: :model do
       expect { new_aggregate.add_positive_rating }
         .to change(new_aggregate.reload, :total_positive).by(1)
     end
+
+    context 'when including stem achiever number' do
+      it 'adds a new positive rating' do
+        expect { new_aggregate.add_positive_rating(user_stem_achiever_contact_no) }
+          .to change(Rating, :count).by(1)
+        last_rating = Rating.last
+        expect(last_rating.positive).to eq(true)
+        expect(last_rating.user_stem_achiever_contact_no)
+          .to eq(user_stem_achiever_contact_no)
+      end
+
+      it 'increases total_positive count by 1' do
+        expect do
+          new_aggregate.add_positive_rating(user_stem_achiever_contact_no)
+        end
+          .to change(new_aggregate.reload, :total_positive).by(1)
+      end
+    end
   end
 
   describe '#add_negative_rating' do
@@ -26,6 +46,24 @@ RSpec.describe AggregateRating, type: :model do
     it 'increases total_positive count by 1' do
       expect { new_aggregate.add_negative_rating }
         .to change(new_aggregate.reload, :total_negative).by(1)
+    end
+
+    context 'when including stem achiever number' do
+      it 'adds a new negative rating' do
+        expect { new_aggregate.add_negative_rating(user_stem_achiever_contact_no) }
+          .to change(Rating, :count).by(1)
+        last_rating = Rating.last
+        expect(last_rating.positive).to eq(false)
+        expect(last_rating.user_stem_achiever_contact_no)
+          .to eq(user_stem_achiever_contact_no)
+      end
+
+      it 'increases total_negative count by 1' do
+        expect do
+          new_aggregate.add_negative_rating(user_stem_achiever_contact_no)
+        end
+          .to change(new_aggregate.reload, :total_negative).by(1)
+      end
     end
   end
 end

--- a/spec/requests/add_lesson_ratings_spec.rb
+++ b/spec/requests/add_lesson_ratings_spec.rb
@@ -2,26 +2,29 @@ require 'rails_helper'
 
 RSpec.describe 'Add Lesson Rating', type: :request do
   let(:published_lesson) { create(:published_lesson) }
+  let(:user_stem_achiever_contact_no) { SecureRandom.uuid }
 
   describe 'add positive rating' do
-    it 'returns the lesson information' do
-      query = {
-        query: <<~GQL
-          mutation {
-            addPositiveLessonRating(
-              id: "#{published_lesson.id}"
-            )
-            {
-              id
-              title
-              description
-              totalPositive
-              totalNegative
-            }
+    let(:query) do
+      { query: <<~GQL
+        mutation {
+          addPositiveLessonRating(
+            id: "#{published_lesson.id}"
+            userStemAchieverContactNo: "#{user_stem_achiever_contact_no}"
+          )
+          {
+            id
+            title
+            description
+            totalPositive
+            totalNegative
           }
-        GQL
+        }
+      GQL
       }
+    end
 
+    it 'returns the lesson information' do
       post '/graphql', params: query
       expect(response).to be_successful
 
@@ -39,14 +42,18 @@ RSpec.describe 'Add Lesson Rating', type: :request do
 
       expect(response.body).to eq(expected_response)
     end
-  end
 
-  describe 'add negative rating' do
-    it 'returns the lesson information' do
-      query = {
-        query: <<~GQL
+    it 'calls add_positive_rating method with the stem achiever number' do
+      expect_any_instance_of(Lesson)
+        .to receive(:add_positive_rating).with(user_stem_achiever_contact_no)
+      post '/graphql', params: query
+    end
+
+    context 'when no achiever number included' do
+      let(:query) do
+        { query: <<~GQL
           mutation {
-            addNegativeLessonRating(
+            addPositiveLessonRating(
               id: "#{published_lesson.id}"
             )
             {
@@ -58,8 +65,52 @@ RSpec.describe 'Add Lesson Rating', type: :request do
             }
           }
         GQL
-      }
+        }
+      end
 
+      it 'returns the lesson information' do
+        post '/graphql', params: query
+        expect(response).to be_successful
+
+        expected_response = {
+          data: {
+            addPositiveLessonRating: {
+              id: published_lesson.id,
+              title: published_lesson.title,
+              description: published_lesson.description,
+              totalPositive: 1,
+              totalNegative: 0
+            }
+          }
+        }.to_json
+
+        expect(response.body).to eq(expected_response)
+      end
+    end
+  end
+
+  describe 'add negative rating' do
+    let(:query) do
+      {
+        query: <<~GQL
+          mutation {
+            addNegativeLessonRating(
+              id: "#{published_lesson.id}"
+              userStemAchieverContactNo: "#{user_stem_achiever_contact_no}"
+            )
+            {
+              id
+              title
+              description
+              totalPositive
+              totalNegative
+            }
+          }
+        GQL
+      }
+    end
+
+    it 'returns the lesson information' do
       post '/graphql', params: query
       expect(response).to be_successful
 
@@ -76,6 +127,52 @@ RSpec.describe 'Add Lesson Rating', type: :request do
       }.to_json
 
       expect(response.body).to eq(expected_response)
+    end
+
+    it 'calls add_negative_rating method with the stem achiever number' do
+      expect_any_instance_of(Lesson)
+        .to receive(:add_negative_rating).with(user_stem_achiever_contact_no)
+      post '/graphql', params: query
+    end
+
+    context 'when no achiever number included' do
+      let(:query) do
+        {
+          query: <<~GQL
+            mutation {
+              addNegativeLessonRating(
+                id: "#{published_lesson.id}"
+              )
+              {
+                id
+                title
+                description
+                totalPositive
+                totalNegative
+              }
+            }
+          GQL
+        }
+      end
+
+      it 'returns the lesson information' do
+        post '/graphql', params: query
+        expect(response).to be_successful
+
+        expected_response = {
+          data: {
+            addNegativeLessonRating: {
+              id: published_lesson.id,
+              title: published_lesson.title,
+              description: published_lesson.description,
+              totalPositive: 0,
+              totalNegative: 1
+            }
+          }
+        }.to_json
+
+        expect(response.body).to eq(expected_response)
+      end
     end
   end
 end

--- a/spec/requests/add_unit_ratings_spec.rb
+++ b/spec/requests/add_unit_ratings_spec.rb
@@ -2,14 +2,16 @@ require 'rails_helper'
 
 RSpec.describe 'Add Unit Rating', type: :request do
   let(:published_unit) { create(:published_unit) }
+  let(:user_stem_achiever_contact_no) { SecureRandom.uuid }
 
   describe 'add positive rating' do
-    it 'returns the unit information' do
-      query = {
+    let(:query) do
+      {
         query: <<~GQL
           mutation {
             addPositiveUnitRating(
               id: "#{published_unit.id}"
+              userStemAchieverContactNo: "#{user_stem_achiever_contact_no}"
             )
             {
               id
@@ -22,7 +24,9 @@ RSpec.describe 'Add Unit Rating', type: :request do
           }
         GQL
       }
+    end
 
+    it 'returns the unit information' do
       post '/graphql', params: query
       expect(response).to be_successful
 
@@ -41,15 +45,64 @@ RSpec.describe 'Add Unit Rating', type: :request do
 
       expect(response.body).to eq(expected_response)
     end
+
+    it 'calls add_positive_rating method with the stem achiever number' do
+      expect_any_instance_of(Unit)
+        .to receive(:add_positive_rating).with(user_stem_achiever_contact_no)
+      post '/graphql', params: query
+    end
+
+    context 'when no achiever contact number' do
+      let(:query) do
+        {
+          query: <<~GQL
+            mutation {
+              addPositiveUnitRating(
+                id: "#{published_unit.id}"
+              )
+              {
+                id
+                title
+                description
+                unitGuide
+                totalPositive
+                totalNegative
+              }
+            }
+          GQL
+        }
+      end
+
+      it 'returns the unit information' do
+        post '/graphql', params: query
+        expect(response).to be_successful
+
+        expected_response = {
+          data: {
+            addPositiveUnitRating: {
+              id: published_unit.id,
+              title: published_unit.title,
+              description: published_unit.description,
+              unitGuide: nil,
+              totalPositive: 1,
+              totalNegative: 0
+            }
+          }
+        }.to_json
+
+        expect(response.body).to eq(expected_response)
+      end
+    end
   end
 
   describe 'add negative rating' do
-    it 'returns the unit information' do
-      query = {
+    let(:query) do
+      {
         query: <<~GQL
           mutation {
             addNegativeUnitRating(
               id: "#{published_unit.id}"
+              userStemAchieverContactNo: "#{user_stem_achiever_contact_no}"
             )
             {
               id
@@ -62,7 +115,9 @@ RSpec.describe 'Add Unit Rating', type: :request do
           }
         GQL
       }
+    end
 
+    it 'returns the unit information' do
       post '/graphql', params: query
       expect(response).to be_successful
 
@@ -80,6 +135,54 @@ RSpec.describe 'Add Unit Rating', type: :request do
       }.to_json
 
       expect(response.body).to eq(expected_response)
+    end
+
+    it 'calls add_negative_rating method with the stem achiever number' do
+      expect_any_instance_of(Unit)
+        .to receive(:add_negative_rating).with(user_stem_achiever_contact_no)
+      post '/graphql', params: query
+    end
+
+    context 'when no achiever number sent' do
+      let(:query) do
+        {
+          query: <<~GQL
+            mutation {
+              addNegativeUnitRating(
+                id: "#{published_unit.id}"
+              )
+              {
+                id
+                title
+                description
+                unitGuide
+                totalPositive
+                totalNegative
+              }
+            }
+          GQL
+        }
+      end
+
+      it 'returns the unit information' do
+        post '/graphql', params: query
+        expect(response).to be_successful
+
+        expected_response = {
+          data: {
+            addNegativeUnitRating: {
+              id: published_unit.id,
+              title: published_unit.title,
+              description: published_unit.description,
+              unitGuide: nil,
+              totalPositive: 0,
+              totalNegative: 1
+            }
+          }
+        }.to_json
+
+        expect(response.body).to eq(expected_response)
+      end
     end
   end
 end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*
* Related to tc#1374

## Review progress:

- [ ] Tech review completed

## What's changed?

* Adds user stem achiever number to ratings model
* Adds user stem achiever number field to ratings mutations 
* stores achiever number in database when user rates unit or lesson
* Handles field not being present so this work can be merged without interfering with current front end implementation
