### PR TITLE
Add rake task to clean up ratings

### DIFF
--- a/lib/tasks/ratings.rake
+++ b/lib/tasks/ratings.rake
@@ -1,0 +1,16 @@
+namespace :ratings do
+  desc "Clears ratings with no stem achiever number and resets aggregate rating
+  totals"
+  task tidy: :environment do
+    AggregateRating.all.each do |ar|
+      ar.ratings.where(user_stem_achiever_contact_no: nil).delete_all
+
+      ar.with_lock do
+        positive_total = ar.ratings.where(positive: true).count
+        negative_total = ar.ratings.where(positive: false).count
+
+        ar.update_attributes(total_negative: negative_total, total_positive: positive_total)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Review App: *populate this once the PR has been created*
* Closes tc#1411

## What's changed?

* Rake task to delete all ratings which don't have a user_stem_achiever_no attached, then recalculate aggregate totals.

## Steps to perform after deploying to production

*Back up the database before running this!*
