### PR TITLE
remove datadog buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -47,9 +47,6 @@
   ],
   "buildpacks": [
     {
-      "url": "https://github.com/DataDog/heroku-buildpack-datadog"
-    },
-    {
       "url": "heroku/nodejs"
     },
     {


### PR DESCRIPTION
## Status

* Current Status: Ready
* Review App: *populate this once the PR has been created*
* Closes https://github.com/NCCE/teachcomputing.org/pull/1124

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

Remove datadog buildpack as its not required for heroku stats
