### PR TITLE
Add task to monitor vital records

### DIFF
--- a/lib/tasks/vital_model_checker.rake
+++ b/lib/tasks/vital_model_checker.rake
@@ -1,0 +1,17 @@
+task :vital_model_checker do
+  aggregate_download_count = AggregateDownload.where(updated_at: (Time.now - 12.hours)..Time.now).count
+
+  Sentry.capture_message('No update to AggregateDownload within the last 12 hours. Please check.') if aggregate_download_count == 0
+
+  download_count = Download.where(created_at: (Time.now - 12.hours)..Time.now).count
+
+  Sentry.capture_message('No Downloads recorded within the last 12 hours. Please check.') if download_count == 0
+
+  ratings_count = Rating.where(updated_at: (Time.now - 24.hours)..Time.now).count
+
+  Sentry.capture_message('No Ratings recorded within the last 24 hours. Please check.') if ratings_count == 0
+
+  aggregate_rating_count = AggregateRating.where(updated_at: (Time.now - 24.hours)..Time.now).count
+
+  Sentry.capture_message('No update to AggregateRating within the last 24 hours. Please check.') if aggregate_rating_count == 0
+end


### PR DESCRIPTION
## Status

* Current Status: WIP
* Review App: *populate this once the PR has been created*
* Related to https://github.com/NCCE/teachcomputing.org-issues/issues/1811

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

- Add task that checks created at and updated at values for specific records. If they are 0 then we send a message to Sentry
