### PR TITLE
Add support for passing a limit in curriculum queries

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,13 +1,13 @@
 module Types
   class QueryType < BaseObject
-    field :year_groups, [Types::YearGroupType], null: true
-    field :key_stages, [Types::KeyStageType], null: true
-    field :lessons, [Types::LessonType], null: true
-    field :units, [Types::UnitType], null: true
+    # Key stages
 
-    field :year_group, Types::YearGroupType, null: true do
-      argument :id, ID, required: false
-      argument :slug, String, required: false
+    field :key_stages, [Types::KeyStageType], null: true do
+      argument :limit, Integer, required: false
+    end
+
+    def key_stages(**args)
+      KeyStage.published.ordered.limit(args[:limit])
     end
 
     field :key_stage, Types::KeyStageType, null: true do
@@ -15,9 +15,37 @@ module Types
       argument :slug, String, required: false
     end
 
-    field :lesson, Types::LessonType, null: true do
+    def key_stage(**args)
+      find_record(KeyStage, args)
+    end
+
+    # Year groups
+
+    field :year_groups, [Types::YearGroupType], null: true do
+      argument :limit, Integer, required: false
+    end
+
+    def year_groups(**args)
+      YearGroup.published.limit(args[:limit])
+    end
+
+    field :year_group, Types::YearGroupType, null: true do
       argument :id, ID, required: false
       argument :slug, String, required: false
+    end
+
+    def year_group(**args)
+      find_record(YearGroup, args)
+    end
+
+    # Units
+
+    field :units, [Types::UnitType], null: true do
+      argument :limit, Integer, required: false
+    end
+
+    def units(**args)
+      Unit.published.ordered.limit(args[:limit])
     end
 
     field :unit, Types::UnitType, null: true do
@@ -25,43 +53,32 @@ module Types
       argument :slug, String, required: false
     end
 
-    # year groups
-    def year_groups
-      YearGroup.published
+    def unit(**args)
+      find_record(Unit, args)
     end
 
-    def year_group(**args)
-      find_record_by_shared_args(YearGroup, args)
+    # Lessons
+
+    field :lessons, [Types::LessonType], null: true do
+      argument :limit, Integer, required: false
     end
 
-    # key stages
-    def key_stages
-      KeyStage.published.ordered
+    def lessons(**args)
+      Lesson.published.ordered.limit(args[:limit])
     end
 
-    def key_stage(**args)
-      find_record_by_shared_args(KeyStage, args)
-    end
-
-    # lesson
-    def lessons
-      Lesson.published.ordered
+    field :lesson, Types::LessonType, null: true do
+      argument :id, ID, required: false
+      argument :slug, String, required: false
     end
 
     def lesson(**args)
-      find_record_by_shared_args(Lesson, args)
+      find_record(Lesson, args)
     end
 
-    # unit
-    def units
-      Unit.published.ordered
-    end
+    # Shared
 
-    def unit(**args)
-      find_record_by_shared_args(Unit, args)
-    end
-
-    def find_record_by_shared_args(model, args)
+    def find_record(model, args)
       id, slug = args.values_at(:id, :slug)
 
       if id

--- a/spec/requests/query_spec.rb
+++ b/spec/requests/query_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Query', type: :request do
-  let!(:published_key_stage) { create(:published_key_stage) }
+  let!(:published_key_stages) { create_list(:published_key_stage, 3) }
+  let!(:published_year_groups) { create_list(:published_year_group, 3) }
+  let!(:published_units) { create_list(:published_unit, 3) }
+  let!(:published_lessons) { create_list(:published_lesson, 3) }
 
   before do
     create(:key_stage)
@@ -9,11 +12,11 @@ RSpec.describe 'Query', type: :request do
 
   describe 'parameter handling' do
     context 'with a keyStage query' do
-      it 'returns the expected value when a slug is passed' do
+      it 'returns the expected value when an id is passed' do
         post '/graphql', params: {
           query: <<~GQL
             {
-              keyStage(slug: "#{published_key_stage.slug}")
+              keyStage(id: "#{published_key_stages[0].id}")
                 {
                   id
                   slug
@@ -25,10 +28,112 @@ RSpec.describe 'Query', type: :request do
         expected_response = {
           data: {
             keyStage: {
-              id: published_key_stage.id,
-              slug: published_key_stage.slug
+              id: published_key_stages[0].id,
+              slug: published_key_stages[0].slug
             }
           }
+        }.to_json
+        expect(response.body).to eq(expected_response)
+      end
+
+      it 'returns the expected value when a slug is passed' do
+        post '/graphql', params: {
+          query: <<~GQL
+            {
+              keyStage(slug: "#{published_key_stages[0].slug}")
+                {
+                  id
+                  slug
+                }
+            }
+          GQL
+        }
+        expect(response).to be_successful
+        expected_response = {
+          data: {
+            keyStage: {
+              id: published_key_stages[0].id,
+              slug: published_key_stages[0].slug
+            }
+          }
+        }.to_json
+        expect(response.body).to eq(expected_response)
+      end
+
+      it 'returns the expected number of items when a limit is set' do
+        post '/graphql', params: {
+          query: <<~GQL
+            {
+              keyStages(limit: 2)
+                {
+                  id
+                }
+            }
+          GQL
+        }
+        expect(response).to be_successful
+        expected_response = {
+          data: { keyStages: [{ id: published_key_stages[0].id }, { id: published_key_stages[1].id }] }
+        }.to_json
+        expect(response.body).to eq(expected_response)
+      end
+    end
+
+    context 'with a yearGroup query' do
+      it 'returns the expected number of items when a limit is set' do
+        post '/graphql', params: {
+          query: <<~GQL
+            {
+              yearGroups(limit: 2)
+                {
+                  id
+                }
+            }
+          GQL
+        }
+        expect(response).to be_successful
+        expected_response = {
+          data: { yearGroups: [{ id: published_year_groups[0].id }, { id: published_year_groups[1].id }] }
+        }.to_json
+        expect(response.body).to eq(expected_response)
+      end
+    end
+
+    context 'with a unit query' do
+      it 'returns the expected number of items when a limit is set' do
+        post '/graphql', params: {
+          query: <<~GQL
+            {
+              units(limit: 2)
+                {
+                  id
+                }
+            }
+          GQL
+        }
+        expect(response).to be_successful
+        expected_response = {
+          data: { units: [{ id: published_units[0].id }, { id: published_units[1].id }] }
+        }.to_json
+        expect(response.body).to eq(expected_response)
+      end
+    end
+
+    context 'with a lesson query' do
+      it 'returns the expected number of items when a limit is set' do
+        post '/graphql', params: {
+          query: <<~GQL
+            {
+              lessons(limit: 2)
+                {
+                  id
+                }
+            }
+          GQL
+        }
+        expect(response).to be_successful
+        expected_response = {
+          data: { lessons: [{ id: published_lessons[0].id }, { id: published_lessons[1].id }] }
         }.to_json
         expect(response.body).to eq(expected_response)
       end


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## Review progress:

- [ ] Browser tested
- [ ] Front-end review completed
- [ ] Tech review completed

## What's changed?

* Adds support for passing a limit argument into queries for the main curriculum data types

## Steps to perform after deploying to production

* N/A
