### PR TITLE
Amend how params are passed to sidekiq

### DIFF
--- a/app/services/update_notifier.rb
+++ b/app/services/update_notifier.rb
@@ -22,6 +22,6 @@ class UpdateNotifier
     def resource_hash(resource)
       type = resource.class.to_s.underscore.parameterize
       identifier = @identifiers[type.to_sym] unless @identifiers.nil?
-      { type: type, identifier: identifier || resource.slug }
+      { 'type' => type, 'identifier' => identifier || resource.slug }
     end
 end

--- a/spec/services/update_notifier_spec.rb
+++ b/spec/services/update_notifier_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe UpdateNotifier do
         notifier.run
         expect(InvalidateCacheWorker)
           .to have_received(:perform_async)
-          .with({ type: 'unit', identifier: 'unit-slug' }).once
+          .with({ 'type' => 'unit', 'identifier' => 'unit-slug' }).once
       end
     end
 
@@ -34,13 +34,13 @@ RSpec.describe UpdateNotifier do
         notifier.run
         expect(InvalidateCacheWorker)
           .to have_received(:perform_async)
-          .with({ type: 'key_stage', identifier: 'ks-slug' }).once
+          .with({ 'type' => 'key_stage', 'identifier' => 'ks-slug' }).once
         expect(InvalidateCacheWorker)
           .to have_received(:perform_async)
-          .with({ type: 'unit', identifier: 'unit-slug' }).once
+          .with({ 'type' => 'unit', 'identifier' => 'unit-slug' }).once
         expect(InvalidateCacheWorker)
           .to have_received(:perform_async)
-          .with({ type: 'lesson', identifier: 'lesson-slug' }).once
+          .with({ 'type' => 'lesson', 'identifier' => 'lesson-slug' }).once
       end
     end
   end


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## What's changed?

* As per [Sidekiq best practices](https://github.com/mperham/sidekiq/wiki/Best-Practices) arguments passed to `perform_async` must be simple types and can not use symbols. This includes using symbol keys in a hash. This was causing a huge number of warnings to be printed in test output, and will error when sidekiq moves to version 7.
* Amend the arguments passed to the invalidate cache worker to use string keys instead of symbols.
