### PR TITLE
Set postgres version to match prod

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         aliases:
           - teachcomputing.rpfdev.com
   db:
-    image: postgres
+    image: postgres:12.9
     volumes:
       - pg-data:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
## Status

* Current Status: Ready for review

## What's changed?

* Set the postgres version in Docker compose to 12.9 to match production database.

## Steps to perform after merge

To get your local docker versions matched up you'll need to remove volumes and then rebuild.
`docker-compose down -v` to remove volumes
`docker-compose up --build` to re build.
