### PR TITLE
Prevent deletion of lessons and units (through Administrate)

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
       post '/publish', to: 'year_groups#publish'
       post '/unpublish', to: 'year_groups#unpublish'
     end
-    resources :units do
+    resources :units, only: %i[new show edit index update] do
       post '/publish', to: 'units#publish'
       post '/unpublish', to: 'units#unpublish'
       delete :unit_guide, action: :destroy_unit_guide
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
       delete :summative_assessments, action: :destroy_summative_assessment
       delete :summative_answers, action: :destroy_summative_answer
     end
-    resources :lessons do
+    resources :lessons, only: %i[new show edit index update] do
       post '/publish', to: 'lessons#publish'
       post '/unpublish', to: 'lessons#unpublish'
       delete :zipped_contents, action: :destroy_zipped_contents


### PR DESCRIPTION
## Status

* Current Status: Ready for review
* Closes https://github.com/NCCE/teachcomputing.org-issues/issues/2049

## What's changed?

Prevents the deletion of lessons and units when using Administrate through explicitly setting the permitted actions on the relevant routes and leaving out `destroy`.

This is handled through routes since Administrate is the only part of the application that interacts with these models in a write capacity. 