### PR TITLE
Enable password on dev redis

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -9,7 +9,7 @@ DEV_PASS=CHANGEME
 TC_API_SECRET=changeme
 
 TC_API_URL=https://teachcomputing.rpfdev.com
-REDIS_URL=redis://localhost:6379/0
-
+REDIS_URL=redis://:redisPassword@localhost:6379/0
+REDIS_HOST_PASSWORD=redisPassword
 # Disable this to prevent these jobs being queued if you're not working in this area
 DISABLE_CACHE_INVALIDATION=true

--- a/.env-example
+++ b/.env-example
@@ -9,7 +9,7 @@ DEV_PASS=CHANGEME
 TC_API_SECRET=changeme
 
 TC_API_URL=https://teachcomputing.rpfdev.com
-REDIS_URL=redis://:redisPassword@localhost:6379/0
-REDIS_HOST_PASSWORD=redisPassword
+REDIS_URL=redis://:CHANGEME@localhost:6379/0
+REDIS_HOST_PASSWORD=CHANGEME
 # Disable this to prevent these jobs being queued if you're not working in this area
 DISABLE_CACHE_INVALIDATION=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,13 @@ services:
       - .env
   redis:
     image: "redis:alpine"
+    command: redis-server --requirepass $REDIS_HOST_PASSWORD
     ports:
       - "6380:6379"
     restart: unless-stopped
     env_file:
       - .env
+
   sidekiq:
     build: .
     command: bundle exec sidekiq
@@ -36,12 +38,12 @@ services:
       - .:/app
       - bundle:/usr/local/bundle
     environment:
-      - REDIS_URL=redis://redis:6379/1
       - TC_API_URL=http://teachcomputing.rpfdev.com
       - TC_API_SECRET=secret
     restart: unless-stopped
     env_file:
       - .env
+
   curriculum:
     build: .
     command: ./scripts/docker-entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+
   redis:
     image: "redis:alpine"
     command: redis-server --requirepass $REDIS_HOST_PASSWORD
@@ -63,10 +64,12 @@ services:
     environment:
       - PROXY_URL=http://host.docker.internal:8888
       - RAILS_DEV_DB_PASS=${DEV_PASS}
-      - REDIS_URL=redis://redis:6379/1
+    env_file:
+      - .env
     stdin_open: true
     tty: true # Allow interactive byebug sessions.
     restart: unless-stopped
+
 volumes:
   bundle:
   pg-data:


### PR DESCRIPTION
## Status

* Current Status: Ready for tech

## Review progress:

- [ ] Tech review completed

## What's changed?

- Requested by IT support, unsecured Redis instances detected running on local dev devices, so enabling password by default
