### PR TITLE
Add outer label for pdf and icon fields for key stage edit page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,6 +18,14 @@
   padding: 1.5em;
 }
 
+.field-unit--nested-custom-label {
+  float: left;
+  margin-left: 1rem;
+  text-align: right;
+  width: calc(15% - 1rem);
+  margin-bottom: 1rem;
+}
+
 .no-bottom-margin {
   margin-bottom: 0
 }

--- a/app/views/admin/key_stages/_form.html.erb
+++ b/app/views/admin/key_stages/_form.html.erb
@@ -1,0 +1,53 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= t(
+          "administrate.form.errors",
+          pluralized_errors: pluralize(page.resource.errors.count, t("administrate.form.error")),
+          resource_name: display_resource_name(page.resource_name, singular: true)
+        ) %>
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li class="flash-error"><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes(controller.action_name).each do |attribute| -%>
+    <div class="field-unit--nested-custom-label">
+      <% if attribute.attribute == :journey_progress_pdf_attachment %>
+        <h2>Journey Progress PDF</h2>
+      <% elsif attribute.attribute == :journey_progress_icon_attachment %>
+        <h2>Journey Progress Icon</h2>
+      <% end %>
+    </div>
+
+    <div class="field-unit field-unit--<%= attribute.html_class %> field-unit--<%= requireness(attribute) %>">
+      <%= render_field attribute, f: f %>
+    </div>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/key_stages/edit.html.erb
+++ b/app/views/admin/key_stages/edit.html.erb
@@ -1,0 +1,36 @@
+<%#
+# Edit
+
+This view is the template for the edit page.
+
+It displays a header, and renders the `_form` partial to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) { t("administrate.actions.edit_resource", name: page.page_title) } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      t("administrate.actions.show_resource", name: page.page_title),
+      [namespace, page.resource],
+      class: "button",
+    ) if valid_action?(:show) && show_action?(:show, page.resource) %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <%= render "form", page: page %>
+</section>


### PR DESCRIPTION
## Status

* Current Status: Ready for tech review
* Resolves https://github.com/NCCE/teachcomputing.org-issues/issues/2715

## Review progress:

- [x] Browser tested
- [x] Tech review completed

## What's changed?

- Getting any configuration options to get a label override was proving tricky, possibly since the approach to defining the pdf and icon associations is relatively complex. In the end, I used the Administrate generator to recreate the ERB files for the edit page and added custom field label. 
